### PR TITLE
Silent NPM for readability

### DIFF
--- a/watch-package.js
+++ b/watch-package.js
@@ -40,7 +40,7 @@ module.exports = function watchPackage(pkgDir, exit) {
     if (!pkg.scripts[script]) {
       die('No such script "' + script + '"', 2)
     }
-    var exec = [npm, 'run', script].join(' ')
+    var exec = [npm, 'run', '-s', script].join(' ')
     var patterns = null
     var extensions = null
     var ignores = null


### PR DESCRIPTION
Silent the annoying `npm ERR!` log
Going from

<img width="781" alt="screen shot 2017-01-02 at 13 05 57" src="https://cloud.githubusercontent.com/assets/664177/21588938/4671adfe-d0ec-11e6-9dcc-f7b0e0d3eb35.png">

to

<img width="560" alt="screen shot 2017-01-02 at 13 06 11" src="https://cloud.githubusercontent.com/assets/664177/21588941/4bde3bc2-d0ec-11e6-8f61-1d9ee4479a4d.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-zuber/npm-watch/32)
<!-- Reviewable:end -->
