### PR TITLE
Adding Support for defining one script to run in watch mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules
 
 #vs vnext files
 .vs/
+#vs code files
+.vscode/
+.history/

--- a/README.md
+++ b/README.md
@@ -23,8 +23,41 @@ your `"scripts"`:
 }
 ```
 
+Possibilty to watch for different tasks
+
+```javascript
+  {
+    "watch": 
+      {
+      "run_android": {
+        "patterns": [
+          "app"
+        ],
+        "extensions": "ts,html,scss",
+        "quiet": false
+      },
+      "run_ios": {
+        "patterns": [
+          "app"
+        ],
+        "extensions": "ts,html,scss",
+        "quiet": false
+      }
+    },
+    "scripts": {
+      "watch_android": "npm-watch run_android",
+      "watch_ios": "npm-watch run_ios",
+      "run_android": "tns run android --emulator",
+      "run_ios": "tns run ios --emulator"
+    }
+  }
+```
+
+
 The keys of the `"watch"` config should match the names of your `"scripts"`, and
 the values should be a glob pattern or array of glob patterns to watch.
+
+Also it is now possible to obtain a second parameter to define the script which should be run for watching and not watch all possible scripts at once.
 
 If you need to watch files with extensions other than those that `nodemon` watches [by default](https://github.com/remy/nodemon#specifying-extension-watch-list) (`.js`, `.coffee`, `.litcoffee`), you can set the value to an object with `patterns` and `extensions` keys. You can also add an `ignore` key (a list or a string) to ignore specific files. Finally, you can add a `quiet` flag to hide the script name in any output on stdout or stderr, or you can use the `inherit` flag to preserve the original's process stdout or stderr.
 > The `quiet` flag was changed from a `string` to a `boolean` in `0.1.5`. Backwards compatability will be kept for two patch versions.

--- a/cli.js
+++ b/cli.js
@@ -2,14 +2,17 @@
 'use strict';
 var path = require('path')
 
-var windows = process.platform === 'win32'
+    var windows = process.platform === 'win32'
 var pathVarName = (windows && !('PATH' in process.env)) ? 'Path' : 'PATH'
 
-process.env[pathVarName] += path.delimiter + path.join(__dirname, 'node_modules', '.bin')
+process.env[pathVarName] +=
+    path.delimiter +
+    path.join(__dirname, 'node_modules', '.bin')
 
-var watchPackage = require('./watch-package')
+        var watchPackage = require('./watch-package')
 
-var watcher = watchPackage(process.argv[2] || process.cwd(), process.exit)
+        var watcher = watchPackage(
+            process.argv[3] || process.cwd(), process.exit, process.argv[2])
 
 process.stdin.pipe(watcher)
 watcher.stdout.pipe(process.stdout)

--- a/cli.js
+++ b/cli.js
@@ -1,18 +1,13 @@
 #!/usr/bin/env node
 'use strict';
 var path = require('path')
-
-    var windows = process.platform === 'win32'
+var windows = process.platform === 'win32'
 var pathVarName = (windows && !('PATH' in process.env)) ? 'Path' : 'PATH'
 
-process.env[pathVarName] +=
-    path.delimiter +
-    path.join(__dirname, 'node_modules', '.bin')
+process.env[pathVarName] += path.delimiter + path.join(__dirname, 'node_modules', '.bin')
 
-        var watchPackage = require('./watch-package')
-
-        var watcher = watchPackage(
-            process.argv[3] || process.cwd(), process.exit, process.argv[2])
+var watchPackage = require('./watch-package')
+var watcher = watchPackage(process.argv[3] || process.cwd(), process.exit, process.argv[2])
 
 process.stdin.pipe(watcher)
 watcher.stdout.pipe(process.stdout)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-watch",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "run scripts from package.json when files change",
   "main": "index.js",
   "dependencies": {

--- a/watch-package.js
+++ b/watch-package.js
@@ -16,8 +16,8 @@ module.exports = function watchPackage(_pkgDir, exit, taskName) {
   var pkg = require(path.join(pkgDir, 'package.json'))
   var processes = {}
 
-  if (typeof taskName !== 'undefined' && taskName === '') {
-    console.info('No Task specified. Will go trough all possible tasks');
+  if (typeof taskName !== 'undefined' && taskName.trim() === '') {
+    console.info('No task specified. Will go through all possible tasks');
   }
 
   if (typeof pkg.watch !== 'object') {
@@ -44,7 +44,7 @@ module.exports = function watchPackage(_pkgDir, exit, taskName) {
   stdin.stderr = through()
   stdin.stdout = through()
 
-  if (typeof taskName !== 'undefined' && taskName !== '') {
+  if (typeof taskName !== 'undefined' && taskName.trim() !== '') {
     if (!pkg.scripts[taskName]) {
       die('No such script "' + taskName + '"', 2)
     }

--- a/watch-package.js
+++ b/watch-package.js
@@ -16,7 +16,9 @@ module.exports = function watchPackage(_pkgDir, exit, taskName) {
   var pkg = require(path.join(pkgDir, 'package.json'))
   var processes = {}
 
-  if (typeof taskName !== 'undefined' && taskName.trim() === '') {
+  taskName = typeof taskName !== 'undefined' ? taskName.trim() : '';
+
+  if (taskName === '') {
     console.info('No task specified. Will go through all possible tasks');
   }
 
@@ -44,7 +46,7 @@ module.exports = function watchPackage(_pkgDir, exit, taskName) {
   stdin.stderr = through()
   stdin.stdout = through()
 
-  if (typeof taskName !== 'undefined' && taskName.trim() !== '') {
+  if (taskName !== '') {
     if (!pkg.scripts[taskName]) {
       die('No such script "' + taskName + '"', 2)
     }

--- a/watch-package.js
+++ b/watch-package.js
@@ -8,16 +8,24 @@ var through = require('through2')
 var npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 var nodemon = process.platform === 'win32' ? 'nodemon.cmd' : 'nodemon';
 
-module.exports = function watchPackage(pkgDir, exit) {
+var pkgDir = '';
+var stdin = null;
+
+module.exports = function watchPackage(_pkgDir, exit, taskName) {
+  pkgDir = _pkgDir;
   var pkg = require(path.join(pkgDir, 'package.json'))
   var processes = {}
+
+  if (typeof taskName !== 'undefined' && taskName === '') {
+    console.info('No Task specified. Will go trough all possible tasks');
+  }
 
   if (typeof pkg.watch !== 'object') {
     die('No "watch" config in package.json')
   }
 
   // send 'rs' commands to the right proc
-  var stdin = through(function (line, _, callback) {
+  stdin = through(function (line, _, callback) {
     line = line.toString()
     var match = line.match(/^rs\s+(\w+)/)
     if (!match) {
@@ -36,11 +44,47 @@ module.exports = function watchPackage(pkgDir, exit) {
   stdin.stderr = through()
   stdin.stdout = through()
 
+  if (typeof taskName !== 'undefined' && taskName !== '') {
+    if (!pkg.scripts[taskName]) {
+      die('No such script "' + taskName + '"', 2)
+    }
+    startScript(taskName, pkg, processes);
+  } else {
+
   Object.keys(pkg.watch).forEach(function (script) {
     if (!pkg.scripts[script]) {
       die('No such script "' + script + '"', 2)
     }
-    var exec = [npm, 'run', '-s', script].join(' ')
+    startScript(script, pkg, processes);
+  })
+  }
+
+  return stdin
+
+  function die(message, code) {
+    process.stderr.write(message)
+
+    if (stdin) {
+      stdin.end()
+      stdin.stderr.end()
+      stdin.stdout.end()
+    }
+    exit(code || 1)
+  }
+}
+
+function prefixer(prefix) {
+  return through(function (line, _, callback) {
+    line = line.toString()
+    if (!line.match('to restart at any time')) {
+      this.push(prefix + ' ' + line)
+    }
+    callback()
+  })
+}
+
+function startScript(script, pkg, processes) {
+  var exec = [npm, 'run', '-s', script].join(' ')
     var patterns = null
     var extensions = null
     var ignores = null
@@ -88,28 +132,4 @@ module.exports = function watchPackage(pkgDir, exit) {
       proc.stdout.pipe(prefixer('[' + script + ']')).pipe(stdin.stdout)
       proc.stderr.pipe(prefixer('[' + script + ']')).pipe(stdin.stderr)
     }
-  })
-
-  return stdin
-
-  function die(message, code) {
-    process.stderr.write(message)
-
-    if (stdin) {
-      stdin.end()
-      stdin.stderr.end()
-      stdin.stdout.end()
-    }
-    exit(code || 1)
-  }
-}
-
-function prefixer(prefix) {
-  return through(function (line, _, callback) {
-    line = line.toString()
-    if (!line.match('to restart at any time')) {
-      this.push(prefix + ' ' + line)
-    }
-    callback()
-  })
 }


### PR DESCRIPTION
Hey,

I added and Update so the people can define one script inside the task to run in watch mode.
This is a nice feature if you define more than just one task inside the "watch" Object and not want to run all at once.

Kind regards

Marcel Ploch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-zuber/npm-watch/38)
<!-- Reviewable:end -->
