### PR TITLE
Implement runOnChangeOnly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ the values should be a glob pattern or array of glob patterns to watch.
 Also it is now possible to obtain a second parameter to define the script which should be run for watching and not watch all possible scripts at once.
 
 If you need to watch files with extensions other than those that `nodemon` watches [by default](https://github.com/remy/nodemon#specifying-extension-watch-list) (`.js`, `.coffee`, `.litcoffee`), you can set the value to an object with `patterns` and `extensions` keys. You can also add an `ignore` key (a list or a string) to ignore specific files. Finally, you can add a `quiet` flag to hide the script name in any output on stdout or stderr, or you can use the `inherit` flag to preserve the original's process stdout or stderr. You can enable `nodemon` [legacy watch](https://github.com/remy/nodemon#application-isnt-restarting) and specify the restart [delay](https://github.com/remy/nodemon#delaying-restarting) in milliseconds with the corresponding flags.
+
 > The `quiet` flag was changed from a `string` to a `boolean` in `0.1.5`. Backwards compatability will be kept for two patch versions.
+
+Use  `runOnChangeOnly` to set the nodemon option [--on-change-only](https://github.com/remy/nodemon/blob/master/doc/cli/options.txt "--on-change-only"). Setting this to `true` tells nodemon to execute script on change only, not startup.
 
 ```javascript
 {
@@ -71,7 +74,8 @@ If you need to watch files with extensions other than those that `nodemon` watch
       "ignore": "src/vendor/external.min.js",
       "quiet": true,
       "legacyWatch": true,
-      "delay": 2500
+      "delay": 2500,
+      "runOnChangeOnly": false
     }
   },
   "scripts": {

--- a/watch-package.js
+++ b/watch-package.js
@@ -94,6 +94,7 @@ function startScript(script, pkg, processes) {
     var inherit = null
     var legacyWatch = null
     var delay = null
+	var runOnChangeOnly = null
 
     if (typeof pkg.watch[script] === 'object' && !Array.isArray(pkg.watch[script])) {
       patterns = pkg.watch[script].patterns
@@ -103,6 +104,7 @@ function startScript(script, pkg, processes) {
       inherit = pkg.watch[script].inherit
       legacyWatch = pkg.watch[script].legacyWatch
       delay = pkg.watch[script].delay
+	  runOnChangeOnly = pkg.watch[script].runOnChangeOnly
     } else {
       patterns = pkg.watch[script]
     }
@@ -126,6 +128,7 @@ function startScript(script, pkg, processes) {
     if (ignores) { args = args.concat(ignores) }
     if (legacyWatch) { args = args.concat(['--legacy-watch']) }
     if (delay) { args = args.concat(['--delay', delay + 'ms']) }
+	if (runOnChangeOnly) { args = args.concat(['--on-change-only']) }
     args = args.concat(['--exec', exec])
     var proc = processes[script] = spawn(nodemon, args, {
       env: process.env,


### PR DESCRIPTION
Use  `runOnChangeOnly` to set the nodemon option [--on-change-only](https://github.com/remy/nodemon/blob/master/doc/cli/options.txt "--on-change-only"). Setting this to `true` tells nodemon to execute script on change only, not startup.